### PR TITLE
pash: clear clipboard after a timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Password length:   export PASH_LENGTH=50
 Password pattern:  export PASH_PATTERN=_A-Z-a-z-0-9
 Store location:    export PASH_DIR=~/.local/share/pash
 Clipboard tool:    export PASH_CLIP='xclip -sel c'
-Clipboard timeout: export PASH_TIMEOUT=10 ('off' to disable)
+Clipboard timeout: export PASH_TIMEOUT=15 ('off' to disable)
 ```
 
 ## FAQ
@@ -143,8 +143,8 @@ PASH_CLIP='xclip -sel c' pash copy github
 Set the environment variable `PASH_TIMEOUT` to a valid `sleep` interval or `off` to disable the feature.
 
 ```sh
-# Default: '10'
-export PASH_TIMEOUT=10
+# Default: '15'
+export PASH_TIMEOUT=15
 
 # Disable timeout.
 export PASH_TIMEOUT=off

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Using a key pair:  export PASH_KEYID=XXXXXXXX
 Password length:   export PASH_LENGTH=50
 Password pattern:  export PASH_PATTERN=_A-Z-a-z-0-9
 Store location:    export PASH_DIR=~/.local/share/pash
-Clipboard tool:    export PASH_CLIP='xclip -selection clipboard'
+Clipboard tool:    export PASH_CLIP='xclip -sel c'
 Clipboard timeout: export PASH_TIMEOUT=10
 ```
 
@@ -131,11 +131,11 @@ PASH_DIR=/mnt/drive/pash pash list
 Set the environment variable `PASH_CLIP` to a command.
 
 ```sh
-# Default: 'xclip -selection clipboard'.
-export PASH_CLIP='xclip -selection clipboard'
+# Default: 'xclip -sel c'.
+export PASH_CLIP='xclip -sel c'
 
 # This can also be used as a one-off.
-PASH_CLIP='xclip -selection clipboard' pash copy github
+PASH_CLIP='xclip -sel c' pash copy github
 ```
 
 ### How do I change the clipboard timeout?

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pash
     * [How do I set the password length?](#how-do-i-set-the-password-length)
     * [How do I change the password store location?](#how-do-i-change-the-password-store-location)
     * [How do I change the clipboard tool?](#how-do-i-change-the-clipboard-tool)
+    * [How do I change the clipboard timeout?](#how-do-i-change-the-clipboard-timeout)
     * [How do I change the password generation pattern?](#how-do-i-change-the-password-generation-pattern)
     * [How do I rename an entry?](#how-do-i-rename-an-entry)
     * [How can I migrate from `pass` to `pash`?](#how-can-i-migrate-from-pass-to-pash)
@@ -61,11 +62,12 @@ COMMANDS
 
 OPTIONS
 
-Using a key pair: export PASH_KEYID=XXXXXXXX
-Password length:  export PASH_LENGTH=50
-Password pattern: export PASH_PATTERN=_A-Z-a-z-0-9
-Store location:   export PASH_DIR=~/.local/share/pash
-Clipboard tool:   export PASH_CLIP='xclip -selection clipboard'
+Using a key pair:  export PASH_KEYID=XXXXXXXX
+Password length:   export PASH_LENGTH=50
+Password pattern:  export PASH_PATTERN=_A-Z-a-z-0-9
+Store location:    export PASH_DIR=~/.local/share/pash
+Clipboard tool:    export PASH_CLIP='xclip -selection clipboard'
+Clipboard timeout: export PASH_TIMEOUT=10
 ```
 
 ## FAQ
@@ -134,6 +136,18 @@ export PASH_CLIP='xclip -selection clipboard'
 
 # This can also be used as a one-off.
 PASH_CLIP='xclip -selection clipboard' pash copy github
+```
+
+### How do I change the clipboard timeout?
+
+Set the environment variable `PASH_TIMEOUT` to a command.
+
+```sh
+# Default: '10'
+export PASH_TIMEOUT=10
+
+# This can also be used as a one-off.
+PASH_TIMEOUT=5 pash copy github
 ```
 
 ### How do I change the password generation pattern?

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Password length:   export PASH_LENGTH=50
 Password pattern:  export PASH_PATTERN=_A-Z-a-z-0-9
 Store location:    export PASH_DIR=~/.local/share/pash
 Clipboard tool:    export PASH_CLIP='xclip -sel c'
-Clipboard timeout: export PASH_TIMEOUT=10
+Clipboard timeout: export PASH_TIMEOUT=10 ('off' to disable)
 ```
 
 ## FAQ
@@ -140,11 +140,14 @@ PASH_CLIP='xclip -sel c' pash copy github
 
 ### How do I change the clipboard timeout?
 
-Set the environment variable `PASH_TIMEOUT` to a command.
+Set the environment variable `PASH_TIMEOUT` to a valid `sleep` interval or `off` to disable the feature.
 
 ```sh
 # Default: '10'
 export PASH_TIMEOUT=10
+
+# Disable timeout.
+export PASH_TIMEOUT=off
 
 # This can also be used as a one-off.
 PASH_TIMEOUT=5 pash copy github

--- a/pash
+++ b/pash
@@ -60,11 +60,16 @@ pw_copy() {
     # shellcheck disable=2086
     : "${PASH_CLIP:=xclip -selection clipboard}"
 
+    printf 'Clearing clipboard in "%s" seconds.\n' \
+        "${PASH_TIMEOUT:=10}"
+
     # Wait in the background for the password timeout and
     # clear the clipboard when the timer runs out.
+    #
+    # If the 'sleep' fails, kill the script. This is the
+    # simplest method of aborting from a subshell.
     (
-        printf 'Clearing clipboard in %d seconds.\n' "${PASH_TIMEOUT:=10}"
-        sleep "$PASH_TIMEOUT"
+        sleep "$PASH_TIMEOUT" || kill 0
         printf '' | $PASH_CLIP
     ) &
 

--- a/pash
+++ b/pash
@@ -60,15 +60,15 @@ pw_copy() {
     # shellcheck disable=2086
     : "${PASH_CLIP:=xclip -sel c}"
 
-    printf 'Clearing clipboard in "%s" seconds.\n' \
-        "${PASH_TIMEOUT:=10}"
-
     # Wait in the background for the password timeout and
     # clear the clipboard when the timer runs out.
     #
     # If the 'sleep' fails, kill the script. This is the
     # simplest method of aborting from a subshell.
-    {
+    [ "$PASH_TIMEOUT" != off ] && {
+        printf 'Clearing clipboard in "%s" seconds.\n' \
+            "${PASH_TIMEOUT:=10}"
+
         sleep "$PASH_TIMEOUT" || kill 0
         $PASH_CLIP </dev/null
     } &
@@ -139,7 +139,7 @@ Password length:   export PASH_LENGTH=50
 Password pattern:  export PASH_PATTERN=_A-Z-a-z-0-9
 Store location:    export PASH_DIR=~/.local/share/pash
 Clipboard tool:    export PASH_CLIP='xclip -sel c'
-Clipboard timeout: export PASH_TIMEOUT=10
+Clipboard timeout: export PASH_TIMEOUT=10 ('off' to disable)
 "
 exit 1
 }

--- a/pash
+++ b/pash
@@ -58,7 +58,7 @@ pw_copy() {
     # Disable warning against word-splitting as it is safe
     # and intentional (globbing is disabled).
     # shellcheck disable=2086
-    : "${PASH_CLIP:=xclip -selection clipboard}"
+    : "${PASH_CLIP:=xclip -sel c}"
 
     printf 'Clearing clipboard in "%s" seconds.\n' \
         "${PASH_TIMEOUT:=10}"
@@ -138,7 +138,7 @@ Using a key pair:  export PASH_KEYID=XXXXXXXX
 Password length:   export PASH_LENGTH=50
 Password pattern:  export PASH_PATTERN=_A-Z-a-z-0-9
 Store location:    export PASH_DIR=~/.local/share/pash
-Clipboard tool:    export PASH_CLIP='xclip -selection clipboard'
+Clipboard tool:    export PASH_CLIP='xclip -sel c'
 Clipboard timeout: export PASH_TIMEOUT=10
 "
 exit 1

--- a/pash
+++ b/pash
@@ -67,7 +67,7 @@ pw_copy() {
     # simplest method of aborting from a subshell.
     [ "$PASH_TIMEOUT" != off ] && {
         printf 'Clearing clipboard in "%s" seconds.\n' \
-            "${PASH_TIMEOUT:=10}"
+            "${PASH_TIMEOUT:=15}"
 
         sleep "$PASH_TIMEOUT" || kill 0
         $PASH_CLIP </dev/null
@@ -139,7 +139,7 @@ Password length:   export PASH_LENGTH=50
 Password pattern:  export PASH_PATTERN=_A-Z-a-z-0-9
 Store location:    export PASH_DIR=~/.local/share/pash
 Clipboard tool:    export PASH_CLIP='xclip -sel c'
-Clipboard timeout: export PASH_TIMEOUT=10 ('off' to disable)
+Clipboard timeout: export PASH_TIMEOUT=15 ('off' to disable)
 "
 exit 1
 }

--- a/pash
+++ b/pash
@@ -58,7 +58,17 @@ pw_copy() {
     # Disable warning against word-splitting as it is safe
     # and intentional (globbing is disabled).
     # shellcheck disable=2086
-    pw_show "$1" | ${PASH_CLIP:-xclip -selection clipboard}
+    : "${PASH_CLIP:=xclip -selection clipboard}"
+
+    # Wait in the background for the password timeout and
+    # clear the clipboard when the timer runs out.
+    (
+        printf 'Clearing clipboard in %d seconds.\n' "${PASH_TIMEOUT:=10}"
+        sleep "$PASH_TIMEOUT"
+        printf '' | $PASH_CLIP
+    ) &
+
+    pw_show "$1" | $PASH_CLIP
 }
 
 pw_list() {
@@ -119,11 +129,12 @@ pash 2.1.0 - simple password manager.
 => [l]ist        - List all entries.
 => [s]how [name] - Show password for an entry.
 
-Using a key pair: export PASH_KEYID=XXXXXXXX
-Password length:  export PASH_LENGTH=50
-Password pattern: export PASH_PATTERN=_A-Z-a-z-0-9
-Store location:   export PASH_DIR=~/.local/share/pash
-Clipboard tool:   export PASH_CLIP='xclip -selection clipboard'
+Using a key pair:  export PASH_KEYID=XXXXXXXX
+Password length:   export PASH_LENGTH=50
+Password pattern:  export PASH_PATTERN=_A-Z-a-z-0-9
+Store location:    export PASH_DIR=~/.local/share/pash
+Clipboard tool:    export PASH_CLIP='xclip -selection clipboard'
+Clipboard timeout: export PASH_TIMEOUT=10
 "
 exit 1
 }

--- a/pash
+++ b/pash
@@ -68,10 +68,10 @@ pw_copy() {
     #
     # If the 'sleep' fails, kill the script. This is the
     # simplest method of aborting from a subshell.
-    (
+    {
         sleep "$PASH_TIMEOUT" || kill 0
-        printf '' | $PASH_CLIP
-    ) &
+        $PASH_CLIP </dev/null
+    } &
 
     pw_show "$1" | $PASH_CLIP
 }


### PR DESCRIPTION
This clears the clipboard after a configurable interval by copying a blank string. This uses the same configured `copy` command.

TODO:

- [x] Abort if `PASH_TIMEOUT` is an invalid argument to `sleep`.