### PR TITLE
Fix del command "failing" when password is deleted without deleting parent dir

### DIFF
--- a/pash
+++ b/pash
@@ -60,7 +60,7 @@ pw_del() {
         # Remove empty parent directories of a password
         # entry. It's fine if this fails as it means that
         # another entry also lives in the same directory.
-        rmdir -p "${1%/*}" 2>/dev/null
+        rmdir -p "${1%/*}" 2>/dev/null || true
     }
 }
 

--- a/pash
+++ b/pash
@@ -60,7 +60,7 @@ pw_del() {
         # Remove empty parent directories of a password
         # entry. It's fine if this fails as it means that
         # another entry also lives in the same directory.
-        rmdir -p "${1%/*}" 2>/dev/null || true
+        rmdir -p "${1%/*}" 2>/dev/null || :
     }
 }
 


### PR DESCRIPTION
When deleting a password with `pash del X`, if `rm -f "$1.gpg"` succeeds but `rmdir -p "${1%/*}" 2>/dev/null` fails, the `pash del X` command will appear to fail on exit, despite having actually completed the password deletion.

This PR simply adds `|| true` to `rmdir -p "${1%/*}" 2>/dev/null`, so that if the parent dir still has passwords in it and is not deleted, the `pash del X` command succeeds on exit.