### PR TITLE
Add [e]dit command

### DIFF
--- a/pash
+++ b/pash
@@ -100,6 +100,32 @@ pw_tree() {
     tree --noreport | sed 's/\.gpg$//'
 }
 
+pw_edit() {
+    command -v "$EDITOR" >/dev/null 2>&1 ||
+        die "'$EDITOR' command not found"
+
+    passwordFile="$1.gpg"
+
+    if [ "$PASH_KEYID" ]; then
+        set -- --trust-model always -ar "$PASH_KEYID" -e
+    else
+        set -- -c
+    fi
+
+    TMP_DIR="$(mktemp -d -t "pash-edit.XXXXXXXX")"
+    # Get base name of passwordFile; e.g. websites/github.gpg becomes github.gpg
+    TMP_FILE="$TMP_DIR/${passwordFile##*/}"
+
+    # Remove unencrypted password file when done or if following commands fail
+    trap 'rm -rf $TMP_DIR' INT EXIT
+
+    "$gpg" -qo "$TMP_FILE" -d "$passwordFile"
+
+    "$EDITOR" "$TMP_FILE"
+
+    "$gpg" --yes -o "$passwordFile" "$@" "$TMP_FILE"
+}
+
 yn() {
     printf '%s [y/n]: ' "$1"
 
@@ -189,10 +215,10 @@ main() {
     cd "$PASH_DIR" ||
         die "Can't access password directory"
 
-    glob "$1" '[acds]*' && [ -z "$2" ] &&
+    glob "$1" '[aceds]*' && [ -z "$2" ] &&
         die "Missing [name] argument"
 
-    glob "$1" '[cds]*' && [ ! -f "$2.gpg" ] &&
+    glob "$1" '[cdes]*' && [ ! -f "$2.gpg" ] &&
         die "Pass file '$2' doesn't exist"
 
     glob "$1" 'a*' && [ -f "$2.gpg" ] &&
@@ -224,6 +250,7 @@ main() {
         c*) pw_copy "$2" ;;
         d*) pw_del  "$2" ;;
         s*) pw_show "$2" ;;
+        e*) pw_edit "$2" ;;
         l*) pw_list ;;
         t*) pw_tree ;;
         *)  usage


### PR DESCRIPTION
This pull request adds an [e]dit command to `pash`, allowing easy editing of password files.

I understand your reluctance to use temporary files (leak in `/proc`?); however, I can't really think of a better way to do this apart from using the `sread pass  "Enter password"` code from `pw_add`, but then editing multi-line password files becomes problematic/cumbersome/impossible.

A good solution would be to open a shell variable as a file in an editor, which works, but then saving the edited text back to the shell variable is what I can't figure out how to do.

Without this patch, I would assume the current solution to editing password files is to decrypt, edit, and re-encrypt manually, which is, at best, worst than this solution due to also having to manually delete the unencrypted password file. Additionally, `/tmp` is a `tmpfs` mount on many Linux distributions, which makes recovery of the unencrypted password file more difficult than editing it on a regular file system.