### PR TITLE
Fix error with non-interactive use

### DIFF
--- a/pash
+++ b/pash
@@ -217,7 +217,7 @@ main() {
 
     # Ensure that we leave the terminal in a usable
     # state on exit or Ctrl+C.
-    trap 'stty echo icanon' INT EXIT
+    [ -t 1 ] && trap 'stty echo icanon' INT EXIT
 
     case $1 in
         a*) pw_add  "$2" ;;


### PR DESCRIPTION
If pash is used non-interactively (for example retrieving passwords in msmtp), it is unnecessary to cleanup on exit, and stty outputs the message:
 `stty: standard input: Not a tty`

This fixes the error by checking if stdin is a tty before installing the trap.